### PR TITLE
Simplify line count in formatDoc

### DIFF
--- a/server/src/formatting.ts
+++ b/server/src/formatting.ts
@@ -18,9 +18,8 @@ import { getPerlAssetsPath } from "./assets";
 export function formatDoc(params: DocumentFormattingParams, txtDoc: TextDocument, settings: NavigatorSettings): TextEdit[] | undefined {
     const text = txtDoc.getText();
     const fixedSource = perltidy(text, settings);
-    const lines = text.split(/\r\n|\r|\n/).length;
     const start = { line: 0, character: 0 };
-    const end = { line: lines, character: 0 };
+    const end = { line: txtDoc.lineCount, character: 0 };
     const range = {start, end};
     if(fixedSource){
         let edits: TextEdit = {


### PR DESCRIPTION
This avoids unnecessarily splitting the document lines. Although it does simplify the code slightly and improves its performance, my primary motivation for this change is that the previous line count was actually one higher than it should have been. This would cause some editors, such as helix, to reject the change as it was out of bounds.
