### PR TITLE
fix: criticWrapper.pl PERLCRITIC env should be taken into account

### DIFF
--- a/server/src/perl/criticWrapper.pl
+++ b/server/src/perl/criticWrapper.pl
@@ -72,6 +72,8 @@ sub resolve_profile {
         die("User specified Critic profile $profile not readable");
     }
 
+    return $ENV{'PERLCRITIC'} if $ENV{'PERLCRITIC'} && -r $ENV{'PERLCRITIC'};
+
     if ( my $home_dir = find_home_dir() ) {
         $profile = File::Spec->catfile( $home_dir, '.perlcriticrc' );
         return $profile if -f $profile;


### PR DESCRIPTION
According to the [Perl::Critic documentation](https://metacpan.org/pod/Perl::Critic#CONFIGURATION) if `-profile` option
is not provided the order of searching profiles is following:

1. PERLCRITIC environment variable
2. .perlcritic in the current working directory
3. .perlcritic in the home directory

Previous implementation of criticWrapper.pl ignored existence of PERLCRITIC environment variable completely.