### PR TITLE
First pass at enabling perlimports

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,24 @@
 					"default": true,
 					"description": "Enable warnings using -Mwarnings command switch"
 				},
+				"perlnavigator.perlimportsLintEnabled": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Enable perlimports as a linter."
+				},
+				"perlnavigator.perlimportsTidyEnabled": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Enable perlimports as a tidier."
+				},
+				"perlnavigator.perlimportsProfile": {
+					"scope": "resource",
+					"type": "string",
+					"default": "",
+					"description": "Path to perlimports.toml (no aliases, .bat files or ~/)"
+				},
 				"perlnavigator.perltidyProfile": {
 					"scope": "resource",
 					"type": "string",

--- a/server/src/perl/perlimportsWrapper.pl
+++ b/server/src/perl/perlimportsWrapper.pl
@@ -1,0 +1,34 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Try::Tiny qw( catch try );
+
+if ( !eval { require App::perlimports::CLI; 1 } ) {
+    print "\nUnable to run perlimports as it is not installed\n";
+    exit(0);
+}
+
+my $min = 0.000049;
+if ( $App::perlimports::VERSION < $min ) {
+    printf( "\nNeed at least version %f of perlimports\n", $min);
+    exit(0);
+};
+
+my @args = @ARGV;
+
+push @args, '--read-stdin';
+
+local @ARGV = @args;
+
+my $exit_code = 0;
+try {
+    $exit_code = App::perlimports::CLI->new->run;
+}
+catch {
+    print STDERR $_;
+    $exit_code = 1;
+};
+
+exit($exit_code);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -13,6 +13,9 @@ export interface NavigatorSettings {
     enableWarnings: boolean;
     perlcriticProfile: string;
     perlcriticEnabled: boolean;
+    perlimportsLintEnabled: boolean;
+    perlimportsTidyEnabled: boolean;
+    perlimportsProfile: string;
     perltidyEnabled: boolean;
     perltidyProfile: string;
     severity5: string;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -203,4 +203,11 @@ export function nLog(message: string, settings: NavigatorSettings){
     }
 }
 
+export function getPerlimportsProfile (settings: NavigatorSettings): string[] {
+    const profileCmd: string[] = [];
+    if (settings.perlimportsProfile) {
+        profileCmd.push('--config-file', settings.perlimportsProfile);
+    }
+    return profileCmd;
+}
 


### PR DESCRIPTION
This still needs a lot of work, but I figured I'd create a draft PR to document my progress. `perlimports` as a linter is pretty much working, though.

Closes #22.

<img width="700" alt="Screen Shot 2022-10-21 at 17 57 40" src="https://user-images.githubusercontent.com/96205/197294761-f4b0f724-f280-4c73-9144-5228a0094610.png">

Tasks

- [x] Enable as linter 
- [x] Enable as tidier
- [x] Figure out off-by-one error in line numbering for diagnostics
- [x] Start using config file if configured