### PR TITLE
Correctly Parse Subroutines Following Fat Commas

### DIFF
--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -68,6 +68,8 @@ export function getSymbol(position: Position, txtDoc: TextDocument) {
     let right = index;
 
     while (left >= 0 && leftAllow(text[left])) {
+        // Fat comma check
+        if (text[left] === ">" && left - 1 >= 0 && text[left - 1] === "=") { break; }
         left -= 1;
     }
     left = Math.max(0, left + 1);


### PR DESCRIPTION
#16 Since the left getSymbol regex checks only one character at a time, it seems like we need to add a manual check to make sure ">" is not the end of a fat comma.