### PR TITLE
Compile main extension with webpack and add .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,10 @@
+**/*
+!images/camel_icon.png
+!syntaxes
+!LICENSE
+!client/dist/*
+!server/dist/*
+!server/src/perl
+!perlimports.toml
+!server/perl.tmLanguage.json
+!server/node_modules/vscode-oniguruma/release/onig.wasm

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -18,7 +18,7 @@ let client: LanguageClient;
 export function activate(context: ExtensionContext) {
 	// The server is implemented in node
 	const serverModule = context.asAbsolutePath(
-		path.join('server', 'out', 'server.js')
+		path.join('server', 'dist', 'serverMain.js')
 	);
 	// The debug options for the server
 	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"activationEvents": [
 		"onLanguage:perl"
 	],
-	"main": "./client/out/extension",
+	"main": "./client/dist/clientMain",
 	"browser": "./client/dist/browserClientMain",
 	"contributes": {
 		"configuration": {
@@ -341,7 +341,7 @@
 		]
 	},
 	"scripts": {
-		"vscode:prepublish": "npm run compile",
+		"vscode:prepublish": "npm run package",
 		"compile": "tsc -b",
 		"watch": "tsc -b -w",
 		"web-compile": "export NODE_OPTIONS=--openssl-legacy-provider; webpack",
@@ -376,9 +376,9 @@
 		"ts-loader": "^9.3.0",
 		"path-browserify": "^1.0.1"
 	},
-	"bin": "server/out/server.js",
+	"bin": "server/dist/serverMain.js",
 	"pkg": {
-		"scripts": "server/out/server.js",
+		"scripts": "server/dist/serverMain.js",
 		"assets": "server/src/**/*",
 		"targets": [
 			"node16-linux-x64",

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
 		"vscode-oniguruma": "^2.0.1"
 	},
 	"scripts": {},
-	"main": "./src/out/server.js",
+	"main": "./src/dist/serverMain.js",
 	"bin": {
 		"perlnavigator": "./bin/perlnavigator"
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,103 @@
 const path = require('path');
 
 /** @type WebpackConfig */
+const clientConfig = {
+	context: path.join(__dirname, 'client'),
+	target: 'node', // web extensions run in a webworker context
+	entry: {
+		clientMain: './src/extension.ts',
+	},
+	output: {
+		filename: '[name].js',
+		path: path.join(__dirname, 'client', 'dist'),
+		libraryTarget: 'commonjs',
+	},
+	resolve: {
+		mainFields: ['module', 'main'],
+		extensions: ['.ts', '.js'], // support ts-files and js-files
+		alias: {},
+		fallback: {
+			// path: require.resolve('path-browserify'),
+			path: false,
+			process: false,
+			os: false,
+			fs: false,
+			child_process: false,
+			util: false
+		},
+	},
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				exclude: /node_modules/,
+				use: [
+					{
+						loader: 'ts-loader',
+					},
+				],
+			},
+		],
+	},
+	externals: {
+		vscode: 'commonjs vscode', // ignored because it doesn't exist
+	},
+	performance: {
+		hints: false,
+	},
+	devtool: 'source-map',
+};
+
+/** @type WebpackConfig */
+const serverConfig = {
+	context: path.join(__dirname, 'server'),
+	target: 'node', // web extensions run in a webworker context
+	entry: {
+		serverMain: './src/server.ts',
+	},
+	output: {
+		filename: '[name].js',
+		path: path.join(__dirname, 'server', 'dist'),
+		libraryTarget: 'var',
+		library: 'serverExportVar',
+	},
+	resolve: {
+		mainFields: ['module', 'main'],
+		extensions: ['.ts', '.js'], // support ts-files and js-files
+		alias: {},
+		fallback: {
+			//path: require.resolve("path-browserify")
+			path: false,
+			process: false,
+			os: false,
+			fs: false,
+			child_process: false,
+			util: false
+		},
+	},
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				exclude: /node_modules/,
+				use: [
+					{
+						loader: 'ts-loader',
+					},
+				],
+			},
+		],
+	},
+	externals: {
+		vscode: 'commonjs vscode', // ignored because it doesn't exist
+	},
+	performance: {
+		hints: false,
+	},
+	devtool: 'source-map',
+};
+
+/** @type WebpackConfig */
 const browserClientConfig = {
 	context: path.join(__dirname, 'client'),
 	mode: 'none',
@@ -100,4 +197,4 @@ const browserServerConfig = {
 	devtool: 'source-map',
 };
 
-module.exports = [browserClientConfig, browserServerConfig];
+module.exports = [browserClientConfig, browserServerConfig, clientConfig, serverConfig];


### PR DESCRIPTION
In short this compiles the main extension in a similar fashion to the browser version. This cuts the final .vsix file size down by over half and markedly increases performance on my setup