### PR TITLE
Add perlParams configuration option for passing misc. CLI options to perl

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
 					"default": "perl",
 					"description": "Full path to the perl executable (no aliases, .bat files or ~/)"
 				},
+				"perlnavigator.perlParams": {
+					"scope": "resource",
+					"type": "array",
+					"default": [],
+					"description": "Pass miscellaneous command line arguments to pass to the perl executable"
+				},
 				"perlnavigator.enableWarnings": {
 					"scope": "resource",
 					"type": "boolean",

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -17,7 +17,7 @@ import {
 } from 'vscode-languageserver-textdocument';
 
 export async function perlcompile(textDocument: TextDocument, workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<CompilationResults | void> {
-    let perlParams: string[] = ["-c"];
+    let perlParams: string[] = [...settings.perlParams, "-c"];
     const filePath = Uri.parse(textDocument.uri).fsPath;
 
     if(settings.enableWarnings) perlParams = perlParams.concat(["-Mwarnings", "-M-warnings=redefine"]); // Force enable some warnings.
@@ -165,7 +165,7 @@ function localizeErrors (violation: string, filePath: string, perlDoc: PerlDocum
 export async function perlcritic(textDocument: TextDocument, workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<Diagnostic[]> {
     if(!settings.perlcriticEnabled) return []; 
     const critic_path = join(getPerlAssetsPath(), 'criticWrapper.pl');
-    let criticParams: string[] = [critic_path].concat(getCriticProfile(workspaceFolders, settings));
+    let criticParams: string[] = [...settings.perlParams, critic_path].concat(getCriticProfile(workspaceFolders, settings));
     criticParams = criticParams.concat(['--file', Uri.parse(textDocument.uri).fsPath]);
 
     // Add any extra params from settings
@@ -205,7 +205,7 @@ export async function perlcritic(textDocument: TextDocument, workspaceFolders: W
 export async function perlimports(textDocument: TextDocument, workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<Diagnostic[]> {
     if(!settings.perlimportsLintEnabled) return [];
     const importsPath = join(getPerlAssetsPath(), 'perlimportsWrapper.pl');
-    const cliParams = [importsPath, ...getPerlimportsProfile(settings), '--lint', '--json', '--filename', Uri.parse(textDocument.uri).fsPath];
+    const cliParams = [...settings.perlParams, importsPath, ...getPerlimportsProfile(settings), '--lint', '--json', '--filename', Uri.parse(textDocument.uri).fsPath];
 
     nLog("Now starting perlimports with: " + cliParams.join(" "), settings);
     const code = textDocument.getText();

--- a/server/src/formatting.ts
+++ b/server/src/formatting.ts
@@ -84,7 +84,7 @@ async function perlimports(doc: TextDocument, code: string, settings: NavigatorS
     nLog("Now starting perlimports with: " + cliParams.join(" "), settings);
 
     try {
-        const process = async_execFile(settings.perlPath, cliParams, {timeout: 25000, maxBuffer: 20 * 1024 * 1024});
+        const process = async_execFile(settings.perlPath, settings.perlParams.concat(cliParams), {timeout: 25000, maxBuffer: 20 * 1024 * 1024});
         process?.child?.stdin?.on('error', (error: any) => { 
             nLog("perlImports Error Caught: ", settings);
             nLog(error, settings);
@@ -108,7 +108,7 @@ async function perltidy(code: string, settings: NavigatorSettings, workspaceFold
 
     let output: string | Buffer;
     try {
-        const process = async_execFile(settings.perlPath, tidyParams, {timeout: 25000, maxBuffer: 20 * 1024 * 1024});
+        const process = async_execFile(settings.perlPath, settings.perlParams.concat(tidyParams), {timeout: 25000, maxBuffer: 20 * 1024 * 1024});
         process?.child?.stdin?.on('error', (error: any) => { 
             nLog("PerlTidy Error Caught: ", settings);
             nLog(error, settings);

--- a/server/src/navigation.ts
+++ b/server/src/navigation.ts
@@ -93,7 +93,7 @@ function badFile (file: string){
 
 export async function getAvailableMods(workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<Map<string, string>> {
        
-    let perlParams: string[] = [];
+    let perlParams = settings.perlParams;
     perlParams = perlParams.concat(getIncPaths(workspaceFolders, settings));
     const modHunterPath = join(getPerlAssetsPath(), 'lib_bs22', 'ModHunter.pl');
     perlParams.push(modHunterPath);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -98,6 +98,7 @@ connection.onInitialized(() => {
 // The "real" default settings are in the top-level package.json
 const defaultSettings: NavigatorSettings = {
     perlPath: "perl",
+    perlParams: [],
     enableWarnings: true,
     perlimportsProfile: "",
     perltidyProfile: "",

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -10,6 +10,7 @@ import {
 
 export interface NavigatorSettings {
     perlPath: string;
+    perlParams: string[];
     enableWarnings: boolean;
     perlcriticProfile: string;
     perlcriticEnabled: boolean;


### PR DESCRIPTION
This PR adds a perlParams configuration option to allow setting CLI options for the perl executable in perlPath, since the function that eventually runs perl, `execFile`, only allows a single file in its first argument. An added benefit (and my personal use case) is this allows one to use CPAN module managers such as Carmel and Carton directly via their exec command (which in the case of Carmel makes things a lot smoother in the broadest of terms) like so:

```
"perlnavigator.perlPath": "carmel",
"perlnavigator.perlParams": [
  "exec",
  "perl"
]
```