### PR TITLE
Fix README.md for build from source for other editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Currently, this is not yet packaged for other editors but you can build from sou
 git clone https://github.com/bscan/PerlNavigator
 cd PerlNavigator/
 npm run ci-all
-tsc
+cd server/
+npx tsc
 ```
 
 ### Sublime Text


### PR DESCRIPTION
Running `tsc` in the project root doesn't appear to do anything. Need to `cd` into `server` and then run `tsc`. Calling via `npx` is better here since you don't have to have installed `tsc` globally beforehand.