### PR TITLE
tidyWrapper.pl: Pass -nst switch as $argv along to Perl::Tidy (fixes #36)

### DIFF
--- a/server/src/perl/tidyWrapper.pl
+++ b/server/src/perl/tidyWrapper.pl
@@ -18,6 +18,8 @@ die("PerlTidy profile not readable") if ($profile and !-f $profile); # Profie ma
 
 my ($destination, $stderr, $formatErrors, $argv);
 
+$argv = '-nst';
+
 my $error_flag = Perl::Tidy::perltidy(
     argv        => $argv,
     source      => \$source,


### PR DESCRIPTION
-pbp (Perl best practices) which is often used, includes -st, which is incompatible with this script. But when using perltidy from the command line, -nst is *not* wanted in most cases.

This change adds the -nst option to the arguments passed to Perl::Tidy, making it work for .perltidyrc files which contain -pbp but not -nst.

More details:
* https://metacpan.org/pod/Perl::Tidy#NOTES-ON-FORMATTING-PARAMETERS
* https://metacpan.org/dist/Perl-Tidy/view/bin/perltidy#-pbp,-perl-best-practices