### PR TITLE
add npm install bin entry

### DIFF
--- a/server/bin/perlnavigator
+++ b/server/bin/perlnavigator
@@ -1,0 +1,3 @@
+!/usr/bin/env node
+
+require('../out/server.js');

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,9 @@
 	},
 	"scripts": {},
 	"main": "./src/out/server.js",
+	"bin": {
+		"perlnavigator": "./bin/perlnavigator"
+	},
 	"devDependencies": {},
 	"keywords": [
 		"perl",


### PR DESCRIPTION
According to [https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#bin) this should result in a symlink being made to your system bin folder when installing globally, which means perlnavigator will be immediately usable after `npm install -g perlnavigator-server`. 