### PR TITLE
Improved support for Dancer and Dancer2

### DIFF
--- a/server/src/perl/lib_bs22/pltags.pm
+++ b/server/src/perl/lib_bs22/pltags.pm
@@ -109,8 +109,12 @@ sub CleanForBalanced {
     # $input =~ s@\s//(\n|\s)@ ||$1@g; 
     $input =~ s/[^\x00-\x7F]/ /g;
     $input =~ s/->@\*/ /g;
-    $input =~ s/qr\{[^\}]+\}/ /g;
 
+    # only for Dancer methods
+    if ($input =~ /^(get|any|post|put|patch|delete|del|options|ajax|before_route)/) {
+        $input =~ s/qr\{[^\}]+\}/ /g;
+    }
+    
     # A different approach to keep around; Remove everything except the bare minimum. Will do bracket matching and anything that impacts the interpretation of those brackets (e.g. regex, quotes, comments).
     #$input =~ s/[^\{\}#\\\/"'`]/ /g;
 
@@ -325,12 +329,11 @@ sub build_pltags {
         }
 
         elsif (($sActiveOO->{"Dancer"} or $sActiveOO->{"Dancer2"} or $sActiveOO->{"Mojolicious::Lite"}) and
-            $stmt=~/^(?:any|before\_route)\s+\[([^\]]+)\]\s+(?:=>\h*)?(['"])([^\2]+)\2\s*=>\s*sub/) { # Multiple request routing paths
+            $stmt=~/^(?:any|before\_route)\s+\[([^\]]+)\]\s+(?:=>\h*)?(['"])([^\2]+)\2\h*=>\h*sub/) { # Multiple request routing paths
             my $requests = $1;
-            if ($requests) {
-                $requests =~ s/['"\s\n]+//g;
-            }
-            my $route = "$requests $3";
+            my $route = $3;
+            $requests =~ s/['"\s\n]+//g;
+            my $route = "$requests $route";
             my $end_line = SubEndLine(\@codeClean, $i, $offset);
             MakeTag($route, "g", '', $file, "$line_number;$end_line", $package_name, \@tags);
         }
@@ -350,7 +353,7 @@ sub build_pltags {
         }
 
         elsif (($sActiveOO->{"Dancer"} or $sActiveOO->{"Dancer2"} or $sActiveOO->{"Mojolicious::Lite"}) and
-            $stmt=~/^(?:hook)\s+(['"]|)(\w+)\1\s*(?:=>)?\s*sub/) { # Hooks
+            $stmt=~/^(?:hook)\s+(['"]|)(\w+)\1\s*=>\s*sub/) { # Hooks
             my $hook = $2;
             my $end_line = SubEndLine(\@codeClean, $i, $offset);
             MakeTag($hook, "j", '', $file, "$line_number;$end_line", $package_name, \@tags);

--- a/syntaxes/dancer.json
+++ b/syntaxes/dancer.json
@@ -15,7 +15,7 @@
         "dancer": {
             "patterns": [
                 {
-                    "match": "^\\s*\\b(hook)\\s+(\\w+)\\s+(?==>\\s*sub\\b)",
+                    "match": "^\\s*\\b(hook)\\s+(\\w+)\\s+(?=sub\\b)",
                     "captures": {
                         "1": {
                             "name": "keyword.other.attribute.dancer.perl"
@@ -26,7 +26,7 @@
                     }
                 },
                 {
-                    "match": "^\\s*\\b(get|any|post|put|delete|hook)(?=.*=>\\s*sub\\b)",
+                    "match": "^\\s*\\b(get|any|post|put|patch|delete|del|options|ajax|before_route)(?=.*=>\\s*sub\\b)",
                     "captures": {
                         "1": {
                             "name": "keyword.other.attribute.dancer.perl"

--- a/syntaxes/dancer.json
+++ b/syntaxes/dancer.json
@@ -15,7 +15,7 @@
         "dancer": {
             "patterns": [
                 {
-                    "match": "^\\s*\\b(hook)\\s+(\\w+)\\s+(?=sub\\b)",
+                    "match": "^\\s*\\b(hook)\\s+(\\w+)\\s+(?==>\\s*sub\\b)",
                     "captures": {
                         "1": {
                             "name": "keyword.other.attribute.dancer.perl"


### PR DESCRIPTION
#84 This pull requests does some improvements on the Dancer/Dancer2 support.

- Added some missing keywords like `ajax`, `patch`, `del`
- Added support for the `hook` syntax on Dancer
- Added support for regexp and wildcard matches
- Correctly manage multi request routes: `any ["get", 'post'] => "/route/any" => sub {`
- Added the display of the type of request on the symbol name: `/my/route` => `get /my/route` to make it easier to differentiate between routes using the same name


![Screenshot 2023-08-29 at 12 53 05](https://github.com/bscan/PerlNavigator/assets/581703/8a1b2952-b106-4194-baae-26b5e79fae60)


