### PR TITLE
tidyWrapper.pl: use Perl::Tidy::Sweetened if available

### DIFF
--- a/server/src/perl/tidyWrapper.pl
+++ b/server/src/perl/tidyWrapper.pl
@@ -9,6 +9,11 @@ if ( !eval{ require Perl::Tidy; 1} ){
     exit(0);
 }
 
+my $tidierToUse = Perl::Tidy->can('perltidy');
+if ( eval{ require Perl::Tidy::Sweetened; 1} ){
+    $tidierToUse = Perl::Tidy::Sweetened->can('perltidy');
+}
+
 my ($file, $profile);
 GetOptions ("profile=s" => \$profile);
 
@@ -20,7 +25,7 @@ my ($destination, $stderr, $formatErrors, $argv);
 
 $argv = '-nst';
 
-my $error_flag = Perl::Tidy::perltidy(
+my $error_flag = $tidierToUse->(
     argv        => $argv,
     source      => \$source,
     destination => \$destination,


### PR DESCRIPTION
Perl::Tidy::Sweetened adds support for some syntactic sugar provided by some modules. The module uses Perl::Tidy's prefilter and postfilter hooks to support `method` and `func` keywords (which are also supported on more recent versions of Perl::Tidy) and other stuff.

tidyWrapper.pl is now additionally checking for the availability of the addon module and switches out the `perltidy` method that's being used for tidying.

We are using the builtin universal `can` method to get references to the given sub so we can call them easily later.

More details:
https://metacpan.org/pod/Perl::Tidy::Sweet
https://perldoc.perl.org/UNIVERSAL#CLASS-%3Ecan(-METHOD-)