### PR TITLE
Two commits (can be cherrypicked): Custom Env vars for Perl in settings, and convert tilda to home in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ Sublime Text requires the following minimum settings under LSP settings (modify 
             "selector": "source.perl",
         },
         "settings": {
+            // "perlnavigator.perltidyProfile": "~/.perltidyrc",
+            // "perlnavigator.perlcriticProfile": "~/.perlcriticrc",
             // "perlnavigator.perlEnvAdd": false, // default: true
             // "perlnavigator.perlEnv": {
             //     "KOHA_CONF": "/home/user/git/KohaCommunity/t/data/koha-conf.xml",
             // },
+            // "perlnavigator.perlPath": "~/perl5/perlbrew/perls/perl-5.38.2/bin",
             // "perlnavigator.perlcriticSeverity": 1,
+            // "perlnavigator.includePaths": [ "~/git/KohaCommunity", "~/git/KohaCommunity/lib" ],
             // "perlnavigator.perlcriticEnabled": true,
             // "perlnavigator.enableWarnings": true,
         },

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Sublime Text requires the following minimum settings under LSP settings (modify 
             "command": ["node", "C:\\temp\\PerlNavigator\\server\\out\\server.js","--stdio"],
             "selector": "source.perl",
         },
+        "settings": {
+            // "perlnavigator.perlEnvAdd": false, // default: true
+            // "perlnavigator.perlEnv": {
+            //     "KOHA_CONF": "/home/user/git/KohaCommunity/t/data/koha-conf.xml",
+            // },
+            // "perlnavigator.perlcriticSeverity": 1,
+            // "perlnavigator.perlcriticEnabled": true,
+            // "perlnavigator.enableWarnings": true,
+        },
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -40,6 +40,18 @@
 					"default": [],
 					"description": "Pass miscellaneous command line arguments to pass to the perl executable"
 				},
+				"perlnavigator.perlEnv": {
+					"scope": "resource",
+					"type": "object",
+					"default": {},
+					"description": "Pass environment variables to the perl executable. Skipped if undefined."
+				},
+				"perlnavigator.perlEnvAdd": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Add environment variables to current environment, or totally replace (perlEnv related)."
+				},
 				"perlnavigator.enableWarnings": {
 					"scope": "resource",
 					"type": "boolean",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,6 +17,7 @@ import {
     TextEdit,
 } from "vscode-languageserver/node";
 import { basename } from "path";
+import { homedir } from "os";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { PublishDiagnosticsParams } from "vscode-languageserver-protocol";
 
@@ -192,6 +193,19 @@ async function getWorkspaceFoldersSafe(): Promise<WorkspaceFolder[]> {
     }
 }
 
+function expandTildePaths(paths: string, settings: NavigatorSettings): string {
+    const path = paths;
+    // Consider that this not a Windows feature,
+    // so, Windows "%USERPROFILE%" currently is ignored (and rarely used).
+    if (path.startsWith("~/")) {
+        const newPath = homedir() + path.slice(1);
+        nLog("Expanding tilde path '" + path + "' to '" + newPath + "'", settings);
+        return newPath;
+    } else {
+        return path;
+    }
+}
+
 async function getDocumentSettings(resource: string): Promise<NavigatorSettings> {
     if (!hasConfigurationCapability) {
         return globalSettings;
@@ -204,6 +218,26 @@ async function getDocumentSettings(resource: string): Promise<NavigatorSettings>
         });
         if (!result) return globalSettings;
         const resolvedSettings = { ...globalSettings, ...result };
+
+        if(resolvedSettings.includePaths) {
+            resolvedSettings.includePaths = resolvedSettings.includePaths.map((path: string) => expandTildePaths(path, resolvedSettings));
+        }
+        if(resolvedSettings.perlPath) {
+            resolvedSettings.perlPath = expandTildePaths(resolvedSettings.perlPath, resolvedSettings);
+        }
+        if(resolvedSettings.perlimportsProfile) {
+            resolvedSettings.perlimportsProfile = expandTildePaths(resolvedSettings.perlimportsProfile, resolvedSettings);
+        }
+        if(resolvedSettings.perltidyProfile) {
+            resolvedSettings.perltidyProfile = expandTildePaths(resolvedSettings.perltidyProfile, resolvedSettings);
+        }
+        if(resolvedSettings.perlcriticProfile) {
+            resolvedSettings.perlcriticProfile = expandTildePaths(resolvedSettings.perlcriticProfile, resolvedSettings);
+        }
+        if(resolvedSettings.perlEnv) {
+            resolvedSettings.perlEnv = Object.fromEntries(Object.entries(resolvedSettings.perlEnv).map(([key, value]) => [key, expandTildePaths(value, resolvedSettings)]));
+        }
+
         documentSettings.set(resource, resolvedSettings);
         return resolvedSettings;
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -115,6 +115,8 @@ const defaultSettings: NavigatorSettings = {
     perlimportsTidyEnabled: false,
     perltidyEnabled: true,
     perlCompileEnabled: true,
+    perlEnv: undefined,
+    perlEnvAdd: true,
     severity5: "warning",
     severity4: "info",
     severity3: "hint",

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -20,6 +20,8 @@ export interface NavigatorSettings {
     perltidyEnabled: boolean;
     perltidyProfile: string;
     perlCompileEnabled: boolean;
+    perlEnv: undefined | { [key: string]: string };
+    perlEnvAdd: boolean;
     severity5: string;
     severity4: string;
     severity3: string;


### PR DESCRIPTION
**Feature 1:**

Add support for custom Perl environment variables

Introduced two new environment variables: perlEnv and perlEnvAdd.

- perlEnv: This is a hash to fully override the system's environment for PerlNavigator.
- perlEnvAdd: This is a hash to add or modify specific environment variables for PerlNavigator.

**Feature 2:**

Add support for expanding leading tildas in paths
+ if needed: variable to On/Off that.
