### PR TITLE
Fix warnings via namespace::autoclean

### DIFF
--- a/server/src/perl/Inquisitor.pm
+++ b/server/src/perl/Inquisitor.pm
@@ -16,12 +16,17 @@ $SIG{__WARN__} = sub { warn '=PerlWarning=', @_ };
 # These modules can cause issues because they wipe the symbol table before we get a chance to inspect it.
 # Prevent them from loading. 
 # I hope this doesn't cause any issues, perhaps VERSION numbers or import statements would help here
+#
+# See https://perldoc.perl.org/perldelta#Calling-the-import-method-of-an-unknown-package-produces-a-warning
+# for a discussion of why the stub imports are necessary as of Perl 5.40
 $INC{'namespace/clean.pm'} = '';
 $INC{'namespace/autoclean.pm'} = '';
 {
     no strict 'refs';
     *{'namespace::autoclean::VERSION'} = sub { '0.29' };
     *{'namespace::clean::VERSION'} = sub { '0.27' };
+    *{'namespace::autoclean::import'} = sub { };
+    *{'namespace::clean::import'} = sub { };
 }
 
 CHECK {


### PR DESCRIPTION
On Perl 5.40 a new warning is introduced when the import method of an
unknown package is called.

https://perldoc.perl.org/perldelta#Calling-the-import-method-of-an-unknown-package-produces-a-warning

This is seen via PerlNavigator because Inquisitor.pm removes
namespace::clean and namespace::autoclean from %INC. The solution is to
add stub import subs for these packages so that the Perl interpreter no
longer believes that they do not exist.

<img width="1592" alt="Bildschirmfoto 2024-08-07 um 3 16 27 PM" src="https://github.com/user-attachments/assets/f98f1abf-b0d7-4877-a99b-fc8d6cb5ea3a">
