### PR TITLE
improves field handling when inherited attrs are changed

### DIFF
--- a/browser-ext/src/web-parse.ts
+++ b/browser-ext/src/web-parse.ts
@@ -253,7 +253,7 @@ function fields(state: ParserState) : boolean {
 
     let match;
     // Moo/Moose/Object::Pad/Moops/Corinna attributes
-    if ((match = state.stmt.match(/^(?:has|field)(?:\s+|\()["']?([\$@%]?\w+)\b/))) { 
+    if ((match = state.stmt.match(/^(?:has|field)(?:\s+|\()["']?\+?([\$@%]?\w+)\b/))) {
         const attr = match[1];
         let type;
         if(attr.match(/^\w/)){

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -301,7 +301,7 @@ function constants(state: ParserState): boolean {
 function fields(state: ParserState): boolean {
     let match;
     // Moo/Moose/Object::Pad/Moops/Corinna attributes
-    if ((match = state.stmt.match(/^(?:has|field)(?:\s+|\()["']?([\$@%]?\w+)\b/))) {
+    if ((match = state.stmt.match(/^(?:has|field)(?:\s+|\()["']?\+?([\$@%]?\w+)\b/))) {
         const attr = match[1];
         let type;
         if (attr.match(/^\w/)) {


### PR DESCRIPTION
In Moose/Mouse, a child class can change the meta properties of fields inherited from the parent class, so you might not want to treat a field that hasn't changed as a field of that child class, but if it has changed, you think it's more efficient to show it as a field of the child class.

```perl
package My::Parent;

use Mouse;

has 'name' => (
    ...
);

package My::Child;

use Mouse;

extends 'My::Parent';

has '+name' => (
    default => 'child',
);
```