### PR TITLE
Find onig.wasm dynamically

### DIFF
--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -596,7 +596,6 @@ function PackageEndLine(state: ParserState) {
 
 // Resolve the path to the vscode-oniguruma package
 const onigurumaPkgPath = path.dirname(require.resolve('vscode-oniguruma/package.json'));
-console.log(onigurumaPkgPath);
 // Construct the path to onig.wasm
 const onigWasmPath = path.join(onigurumaPkgPath, 'release', 'onig.wasm');
 // Read the file

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -594,7 +594,13 @@ function PackageEndLine(state: ParserState) {
     return state.codeArray.length;
 }
 
-const wasmBin = fs.readFileSync(path.join(__dirname, "./../node_modules/vscode-oniguruma/release/onig.wasm")).buffer;
+// Resolve the path to the vscode-oniguruma package
+const onigurumaPkgPath = path.dirname(require.resolve('vscode-oniguruma/package.json'));
+console.log(onigurumaPkgPath);
+// Construct the path to onig.wasm
+const onigWasmPath = path.join(onigurumaPkgPath, 'release', 'onig.wasm');
+// Read the file
+const wasmBin = fs.readFileSync(onigWasmPath).buffer;
 const vscodeOnigurumaLib = oniguruma.loadWASM(wasmBin).then(() => {
     return {
         createOnigScanner(patterns: any) {

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -594,12 +594,16 @@ function PackageEndLine(state: ParserState) {
     return state.codeArray.length;
 }
 
-// Resolve the path to the vscode-oniguruma package
-const onigurumaPkgPath = path.dirname(require.resolve('vscode-oniguruma/package.json'));
-// Construct the path to onig.wasm
-const onigWasmPath = path.join(onigurumaPkgPath, 'release', 'onig.wasm');
+// we first try to find by absolute path, which is needed in webpack
+let onigWasmPath = path.join(__dirname, "./../node_modules/vscode-oniguruma/release/onig.wasm")
+if (!fs.existsSync(onigWasmPath)) {
+  // dynmacially retrieve the path to onig.wasm (we need to eval the require to stop webpack from
+  // bundling the wasm, which doesn't werk)
+  onigWasmPath = eval('require.resolve')('vscode-oniguruma/release/onig.wasm');
+}
 // Read the file
 const wasmBin = fs.readFileSync(onigWasmPath).buffer;
+
 const vscodeOnigurumaLib = oniguruma.loadWASM(wasmBin).then(() => {
     return {
         createOnigScanner(patterns: any) {


### PR DESCRIPTION
- **fix: find oniguruma dynamically**
  Sometimes, the vscode-oniguruma package may be hoisted up, so we can't rely on it being
  in a particular node-modules folder. We change it to dynamically find the correct path,
  thus allowing for a non-global npm install!
