### PR TITLE
fix: enable to detect module names validly

### DIFF
--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -54,7 +54,7 @@ export function getSymbol(position: Position, txtDoc: TextDocument) {
     const index = txtDoc.offsetAt(position) - txtDoc.offsetAt(start);
 
     const leftRg = /[\p{L}\p{N}_:>-]/u;
-    const rightRg = /[\p{L}\p{N}_]/u;
+    const rightRg = /[\p{L}\p{N}_:]/u;
 
     const leftAllow = (c: string) => leftRg.exec(c);
     const rightAllow = (c: string) => rightRg.exec(c);


### PR DESCRIPTION
With this, it can detect validly when the cursor is on the left side of module names.

```
-- `|` is the position of the cursur
use Foo::B|ar;  # => can be "Foo::Bar".
use Fo|o::Bar;  # => can be "Foo::Bar". "Foo" without this patch.
```