### PR TITLE
Add support for $workspaceFolder on perlimports options

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -216,7 +216,7 @@ export async function perlcritic(textDocument: TextDocument, workspaceFolders: W
 export async function perlimports(textDocument: TextDocument, workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<Diagnostic[]> {
     if (!settings.perlimportsLintEnabled) return [];
     const importsPath = join(await getPerlAssetsPath(), "perlimportsWrapper.pl");
-    const cliParams = [...settings.perlParams, importsPath, ...getPerlimportsProfile(settings), "--lint", "--json", "--filename", Uri.parse(textDocument.uri).fsPath];
+    const cliParams = [...settings.perlParams, importsPath, ...getPerlimportsProfile(workspaceFolders, settings), "--lint", "--json", "--filename", Uri.parse(textDocument.uri).fsPath];
 
     nLog("Now starting perlimports with: " + cliParams.join(" "), settings);
     const code = textDocument.getText();

--- a/server/src/formatting.ts
+++ b/server/src/formatting.ts
@@ -51,7 +51,7 @@ async function maybeReturnEdits(
 
     const progressToken = await startProgress(connection, "Formatting doc", settings);
     let newSource: string = "";
-    const fixedImports = await perlimports(txtDoc, text, settings);
+    const fixedImports = await perlimports(txtDoc, text, settings, workspaceFolders);
     if (fixedImports) {
         newSource = fixedImports;
     }
@@ -73,10 +73,10 @@ async function maybeReturnEdits(
     return [edits];
 }
 
-async function perlimports(doc: TextDocument, code: string, settings: NavigatorSettings): Promise<string | undefined> {
+async function perlimports(doc: TextDocument, code: string, settings: NavigatorSettings, workspaceFolders: WorkspaceFolder[] | null): Promise<string | undefined> {
     if (!settings.perlimportsTidyEnabled) return;
     const importsPath = join(await getPerlAssetsPath(), "perlimportsWrapper.pl");
-    let cliParams: string[] = [importsPath].concat(getPerlimportsProfile(settings));
+    let cliParams: string[] = [importsPath].concat(getPerlimportsProfile(workspaceFolders, settings));
     cliParams = cliParams.concat(["--filename", Uri.parse(doc.uri).fsPath]);
     nLog("Now starting perlimports with: " + cliParams.join(" "), settings);
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -252,10 +252,22 @@ export function nLog(message: string, settings: NavigatorSettings) {
     }
 }
 
-export function getPerlimportsProfile(settings: NavigatorSettings): string[] {
+export function getPerlimportsProfile(workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): string[] {
     const profileCmd: string[] = [];
     if (settings.perlimportsProfile) {
-        profileCmd.push("--config-file", settings.perlimportsProfile);
+        let profile = settings.perlimportsProfile;
+        if (profile.indexOf("$workspaceFolder") != -1) {
+            if (workspaceFolders) {
+                const workspaceUri = Uri.parse(workspaceFolders[0].uri).fsPath;
+                profileCmd.push("--config-file");
+                profileCmd.push(profile.replaceAll("$workspaceFolder", workspaceUri));
+            } else {
+                nLog("You specified $workspaceFolder in your perlimports path, but didn't include any workspace folders. Ignoring profile.", settings);
+            }
+        } else {
+            profileCmd.push("--config-file");
+            profileCmd.push(profile);
+        }
     }
     return profileCmd;
 }


### PR DESCRIPTION
The workspaceFolder variable was being parsed in different options, but was missing for perlimports specific options. This commit adds this missing support.