### PR TITLE
README: update coc-perl description

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ A simple configuration to enable PerlNavigator, after installing coc-perl (`:Coc
 
 ```json
 {
-  "perl.navigator.enable": true,
-  "perl.navigator.serverPath": "/path/to/PerlNavigator/server/out/server.js"
+  "perlnavigator.enable": true,
+  "perlnavigator.serverPath": "/path/to/PerlNavigator/server/out/server.js"
 }
 ```
 


### PR DESCRIPTION
coc-perl removed the support for their custom configuration namespace, thus we need to update this readme to make it sane.