### PR TITLE
Add support for Perl class syntax ADJUST keyword

### DIFF
--- a/browser-ext/src/web-parse.ts
+++ b/browser-ext/src/web-parse.ts
@@ -214,7 +214,7 @@ function labels(state: ParserState) : boolean {
 
     let match;
     // Phaser block
-    if ((match = state.stmt.match(/^(BEGIN|INIT|CHECK|UNITCHECK|END)\s*\{/))) {
+    if ((match = state.stmt.match(/^(BEGIN|INIT|CHECK|UNITCHECK|END|ADJUST)\s*\{/))) {
         const phaser = match[1];
         const endLine = SubEndLine(state);
 

--- a/server/perl.tmLanguage.json
+++ b/server/perl.tmLanguage.json
@@ -911,7 +911,7 @@
 					"name": "variable.parameter.function.perl"
 				}
 			},
-			"match": "^\\s*(BEGIN|UNITCHECK|CHECK|INIT|END|DESTROY)\\b",
+			"match": "^\\s*(BEGIN|UNITCHECK|CHECK|INIT|END|DESTROY|ADJUST)\\b",
 			"name": "meta.function.perl"
 		},
 		{

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -266,7 +266,7 @@ function look_ahead_signatures(state: ParserState): string[] {
 function labels(state: ParserState): boolean {
     let match;
     // Phaser block
-    if ((match = state.stmt.match(/^(BEGIN|INIT|CHECK|UNITCHECK|END)\s*\{/))) {
+    if ((match = state.stmt.match(/^(BEGIN|INIT|CHECK|UNITCHECK|END|ADJUST)\s*\{/))) {
         const phaser = match[1];
         const endLine = SubEndLine(state);
 


### PR DESCRIPTION
Perl's [new Class syntax](https://perldoc.perl.org/perlclass) defines the [`ADJUST`](https://perldoc.perl.org/perlclass#Adjustment) code block, which is "syntactically similar to BEGIN or INIT blocks". This PR adds the `ADJUST` keyword to several regexes, enabling hover text and ensuring it appears in the Outline viewer.