### PR TITLE
Fix parsing of multi-line extended regex

### DIFF
--- a/server/perl.tmLanguage.json
+++ b/server/perl.tmLanguage.json
@@ -747,7 +747,7 @@
 		{
 			"begin": "\\b(?=(?<!\\\\|\\->)s\\s*([^\\s\\w\\[({<>]))",
 			"comment": "string.regexp.replace.extended",
-			"end": "((([egimosradlupc]*x[egimosradlupc]*)))\\b",
+			"end": "((([egimosradlupc]*x[egimosradlupcx]*)))\\b",
 			"endCaptures": {
 				"1": {
 					"name": "string.regexp.replace.perl"
@@ -785,7 +785,7 @@
 							"name": "punctuation.definition.string.perl"
 						}
 					},
-					"end": "'(?=[egimosradlupc]*x[egimosradlupc]*)\\b",
+					"end": "'(?=[egimosradlupc]*x[egimosradlupcx]*)\\b",
 					"name": "string.regexp.replace.extended.simple_delimiter.perl",
 					"patterns": [
 						{
@@ -800,7 +800,7 @@
 							"name": "punctuation.definition.string.perl"
 						}
 					},
-					"end": "\\1(?=[egimosradlupc]*x[egimosradlupc]*)\\b",
+					"end": "\\1(?=[egimosradlupc]*x[egimosradlupcx]*)\\b",
 					"name": "string.regexp.replace.extended.simple_delimiter.perl",
 					"patterns": [
 						{


### PR DESCRIPTION
In Perl 5.26+, the regex quotelike operator accepts a second `x` modifier to allow whitespace inside of character classes. This can improve readability of complex character classes.

`perl.tmLanguage.json` (including upstream VScode/Textmate) does not parse extended regex with `/xx` correctly when broken across multiple lines.

```perl
# single line is ok
my $single = $foo =~ s/[ \N{NO-BREAK SPACE} \r \n {} " ]/ /grxx;
# multi-line highlights ok without second x
# this is syntactically invalid but useful for comparison
my $multi  = $foo =~ s/[
        \N{NO-BREAK SPACE}
        \r \n
        {}
        "
        ]/ /grx;
# multi line extended breaks when second x is added
my $multi_xx  = $foo =~ s/[
        \N{NO-BREAK SPACE}
        \r \n
        {}
        "
        ]/ /grxx;
# rest of file is now broken because of the second x
```

A simple adjustment to the extended regex 'end' condition to allow the second `x` fixes the parsing error.

I'll try to submit this to upstream Textmate as well but there doesn't seem to be much movement on their perl syntax project.