### PR TITLE
Add configurable Perl::Critic message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Sublime Text requires the following minimum settings under LSP settings (modify 
         "settings": {
             // "perlnavigator.perltidyProfile": "~/.perltidyrc",
             // "perlnavigator.perlcriticProfile": "~/.perlcriticrc",
+            // "perlnavigator.perlcriticMessageFormat": "%m - %e",
             // "perlnavigator.perlEnvAdd": false, // default: true
             // "perlnavigator.perlEnv": {
             //     "KOHA_CONF": "/home/user/git/KohaCommunity/t/data/koha-conf.xml",

--- a/browser-ext/src/web-types.ts
+++ b/browser-ext/src/web-types.ts
@@ -17,6 +17,7 @@ export interface NavigatorSettings {
     perlcriticTheme: undefined | string;
     perlcriticExclude: undefined | string;
     perlcriticInclude: undefined | string;
+    perlcriticMessageFormat: string;
     perlimportsLintEnabled: boolean;
     perlimportsTidyEnabled: boolean;
     perlimportsProfile: string;

--- a/package.json
+++ b/package.json
@@ -115,16 +115,22 @@
 					"type": "string",
 					"description": "Regex pattern with policies to exclude for perl critic (normally in profile)"
 				},
-				"perlnavigator.perlcriticInclude": {
-					"scope": "resource",
-					"type": "string",
-					"description": "Regex pattern with policies to include for perl critic (normally in profile)"
-				},
-				"perlnavigator.perlCompileEnabled": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Enable running perl -c on your code"
+                                "perlnavigator.perlcriticInclude": {
+                                        "scope": "resource",
+                                        "type": "string",
+                                        "description": "Regex pattern with policies to include for perl critic (normally in profile)"
+                                },
+                                "perlnavigator.perlcriticMessageFormat": {
+                                        "scope": "resource",
+                                        "type": "string",
+                                        "default": "%m",
+                                        "description": "Format for Perl::Critic messages. Use %e to include policy explanations"
+                                },
+                                "perlnavigator.perlCompileEnabled": {
+                                        "scope": "resource",
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Enable running perl -c on your code"
 				},
 				"perlnavigator.severity5": {
 					"scope": "resource",

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -190,14 +190,18 @@ export async function perlcritic(textDocument: TextDocument, workspaceFolders: W
     const diagnostics: Diagnostic[] = [];
     let output: string;
     try {
-        const process = async_execFile(settings.perlPath, criticParams, { timeout: 25000 });
-        process?.child?.stdin?.on("error", (error: any) => {
+        const env = { ...process.env } as { [key: string]: string | undefined };
+        if (settings.perlcriticMessageFormat) {
+            env.PERL_NAVIGATOR_CRITIC_MESSAGE_FORMAT = settings.perlcriticMessageFormat;
+        }
+        const criticProcess = async_execFile(settings.perlPath, criticParams, { timeout: 25000, env });
+        criticProcess?.child?.stdin?.on("error", (error: any) => {
             nLog("Perl Critic Error Caught: ", settings);
             nLog(error, settings);
         });
-        process?.child?.stdin?.write(code);
-        process?.child?.stdin?.end();
-        const out = await process;
+        criticProcess?.child?.stdin?.write(code);
+        criticProcess?.child?.stdin?.end();
+        const out = await criticProcess;
         output = out.stdout;
     } catch (error: any) {
         nLog("Perlcritic failed with unknown error", settings);

--- a/server/src/perl/criticWrapper.pl
+++ b/server/src/perl/criticWrapper.pl
@@ -41,7 +41,8 @@ my $exclude_ref = $exclude ? [$exclude] : [] ;
 my $include_ref = $include ? [$include] : [] ;
 
 my $critic = Perl::Critic->new( -profile => $profile, -severity => $severity, -theme => $theme, -exclude => $exclude_ref, -include => $include_ref);
-Perl::Critic::Violation::set_format("%s~|~%l~|~%c~|~%m~|~%p~||~");
+my $message_format = $ENV{'PERL_NAVIGATOR_CRITIC_MESSAGE_FORMAT'} // '%m';
+Perl::Critic::Violation::set_format("%s~|~%l~|~%c~|~${message_format}~|~%p~||~");
 
 my @violations = $critic->critique($doc);
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -114,6 +114,7 @@ const defaultSettings: NavigatorSettings = {
     perlcriticTheme: undefined,
     perlcriticExclude: undefined,
     perlcriticInclude: undefined,
+    perlcriticMessageFormat: "%m",
     perlimportsLintEnabled: false,
     perlimportsTidyEnabled: false,
     perltidyEnabled: true,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -14,6 +14,7 @@ export interface NavigatorSettings {
     perlcriticTheme: undefined | string;
     perlcriticExclude: undefined | string;
     perlcriticInclude: undefined | string;
+    perlcriticMessageFormat: string;
     perlimportsLintEnabled: boolean;
     perlimportsTidyEnabled: boolean;
     perlimportsProfile: string;


### PR DESCRIPTION
## Summary
- allow Perl::Critic message text to include optional explanation using PERL_NAVIGATOR_CRITIC_MESSAGE_FORMAT
- expose new `perlnavigator.perlcriticMessageFormat` setting and documentation

## Testing
- `npm test` *(fails: cannot open ./scripts/e2e.sh)*
- `npm run compile` *(fails: TS2403/require type declarations conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab90729c8323acb90af73cee7136