### PR TITLE
Fix namespace::clean stub missing get_functions and clean_subroutines

### DIFF
--- a/server/src/perl/Inquisitor.pm
+++ b/server/src/perl/Inquisitor.pm
@@ -27,6 +27,14 @@ $INC{'namespace/autoclean.pm'} = '';
     *{'namespace::clean::VERSION'} = sub { '0.27' };
     *{'namespace::autoclean::import'} = sub { };
     *{'namespace::clean::import'} = sub { };
+    *{'namespace::clean::get_functions'} = sub {
+        my ($pragma, $class) = @_;
+        no strict 'refs';
+        return { map { $_ => \&{"${class}::${_}"} }
+                 grep { defined &{"${class}::${_}"} }
+                 keys %{"${class}::"} };
+    };
+    *{'namespace::clean::clean_subroutines'} = sub { };
 }
 
 CHECK {

--- a/t/02_NamespaceClean.t
+++ b/t/02_NamespaceClean.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Capture::Tiny qw( capture );
+use File::Spec;
+use Test::More import => [qw( done_testing is ok like )];
+
+# Prevent Inquisitor's CHECK block from running during test load.
+BEGIN { $ENV{'PERLNAVIGATORTEST'} = 1; }
+
+use FindBin qw( $Bin );
+use lib "$Bin/../server/src/perl";
+use Inquisitor ();
+
+# Regression test: Inquisitor stubs out namespace::clean to prevent it from
+# wiping the symbol table. The stub previously only provided import() and
+# VERSION, omitting get_functions() and clean_subroutines(). Any module that
+# calls namespace::clean->get_functions($package) at file scope would fail with:
+#
+#   Can't locate object method "get_functions" via package "namespace::clean"
+#
+# This caused a cascade of false "Syntax" diagnostics in the editor.
+
+my $testFile = File::Spec->rel2abs("$Bin/../testWorkspace/MyLib/NamespaceCleanCaller.pm");
+
+# Verify get_functions stub exists and is callable.
+ok( namespace::clean->can('get_functions'),
+    'namespace::clean stub provides get_functions method' );
+
+ok( namespace::clean->can('clean_subroutines'),
+    'namespace::clean stub provides clean_subroutines method' );
+
+# Verify get_functions returns a hashref (not undef or an exception).
+my $funcs;
+eval { $funcs = namespace::clean->get_functions('main') };
+is( $@, '', 'namespace::clean->get_functions does not throw' );
+ok( ref($funcs) eq 'HASH', 'namespace::clean->get_functions returns a hashref' );
+
+# Verify that Inquisitor::run() succeeds on a file that calls
+# namespace::clean->get_functions at file scope.
+my $output;
+eval { $output = capture(sub { Inquisitor::run($testFile) }) };
+is( $@, '', 'Inquisitor::run does not die on file using namespace::clean->get_functions' );
+
+# The file should produce symbol output (my_method should appear).
+like( $output, qr/my_method/, 'Symbol from NamespaceCleanCaller.pm is found' );
+
+done_testing;

--- a/testWorkspace/MyLib/NamespaceCleanCaller.pm
+++ b/testWorkspace/MyLib/NamespaceCleanCaller.pm
@@ -1,0 +1,17 @@
+package MyLib::NamespaceCleanCaller;
+
+# This module simulates a pattern where namespace::clean->get_functions()
+# is called at file scope (not inside a BEGIN block). This is legal Perl
+# and works at runtime, but was broken under Inquisitor because the
+# namespace::clean stub only provided import(), not get_functions().
+
+use strict;
+use warnings;
+use namespace::clean;
+
+# Call get_functions at file scope, the way some type-library frameworks do.
+my $functions = namespace::clean->get_functions(__PACKAGE__);
+
+sub my_method { return 42 }
+
+1;


### PR DESCRIPTION

Inquisitor.pm stubs out namespace::clean to prevent it from wiping the symbol table before inspection:


```perl
$INC{'namespace/clean.pm'} = '';
*{'namespace::clean::import'} = sub { };
```

However, the stub only provides import and VERSION. Any module that calls `namespace::clean->get_functions($package)` or `namespace::clean->clean_subroutines(...)` as a class method at file scope — not inside a BEGIN block — will fail with:

> Can't locate object method "get_functions" via package "namespace::clean"

This causes a cascade of BEGIN failed errors through the dependency chain, which perlnavigator surfaces as dozens of false Syntax error diagnostics in the editor — one per line of the stack trace — all pointing to line 1 of the file being checked.

Root Cause
The call to `namespace::clean->get_functions(...)` at file scope is valid Perl and works at runtime, because namespace::clean loads normally. But under -MInquisitor, the real namespace::clean is blocked from loading, and the stub doesn't provide a `get_functions` method.

Fix
Add a working `get_functions` stub that reads CODE symbols from the package stash directly — matching the real implementation's return value — and a no-op `clean_subroutines` stub:

```perl
*{'namespace::clean::get_functions'} = sub {
    my ($pragma, $class) = @_;
    no strict 'refs';
    return { map { $_ => \&{"${class}::${_}"} }
             grep { defined &{"${class}::${_}"} }
             keys %{"${class}::"} };
};
*{'namespace::clean::clean_subroutines'} = sub { };
```

The `clean_subroutines` stub is a safe no-op since symbol table cleanup is intentionally skipped during inspection anyway.

Tests
Added t/02_NamespaceClean.t with a regression test and testWorkspace/MyLib/NamespaceCleanCaller.pm as a fixture that calls `namespace::clean->get_functions(__PACKAGE__)` at file scope. All 6 tests pass.

