### PR TITLE
Skip stack trace continuation lines in compile diagnostic parser

### DIFF
--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -11,7 +11,7 @@ import { parseDocument } from "./parser";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 export async function perlcompile(textDocument: TextDocument, workspaceFolders: WorkspaceFolder[] | null, settings: NavigatorSettings): Promise<CompilationResults | void> {
-    
+
     const parsingPromise = parseDocument(textDocument, ParseType.selfNavigation);
 
     if (!settings.perlCompileEnabled){
@@ -144,6 +144,7 @@ function maybeAddCompDiag(violation: string, severity: DiagnosticSeverity, diagn
 
 function localizeErrors(violation: string, filePath: string, perlDoc: PerlDocument): { violation: string; lineNum: number } | void {
     if (violation.indexOf("Too late to run CHECK block") != -1) return;
+    if (/^\t/.test(violation)) return; // Skip stack trace continuation lines
 
     let match = /^(.+)at\s+(.+?)\s+line\s+(\d+)/i.exec(violation);
 


### PR DESCRIPTION
Perl's warning/error output includes indented stack trace lines (starting with a tab) when a warning or error has a call stack. Each of these lines matches the 'at <file> line <N>' regex and was being parsed as a separate Syntax: diagnostic, causing a single warning to generate 10-30 false errors in the Problems panel.

Fix: skip any line beginning with a tab before attempting to parse it as a diagnostic. Stack trace lines always begin with a tab in Perl's output.